### PR TITLE
Emit TS types on build

### DIFF
--- a/client-library/package.json
+++ b/client-library/package.json
@@ -19,7 +19,7 @@
     "wrangler": "^3.47.0"
   },
   "scripts": {
-    "build": "cd src && swc . -d ../dist",
+    "build": "tsc && cd src && swc . -d ../dist",
     "lint": "biome lint ./src/**.ts",
     "format": "biome check ./src/**.ts --apply",
     "lint:ci": "biome ci ./src/**.ts",

--- a/client-library/tsconfig.json
+++ b/client-library/tsconfig.json
@@ -1,12 +1,17 @@
 {
-	"compilerOptions": {
-		"target": "ESNext",
-		"module": "ESNext",
-		"moduleResolution": "Bundler",
-		"strict": true,
-		"skipLibCheck": true,
-		"lib": ["ESNext"],
-		"types": ["@cloudflare/workers-types"],
-		"noEmit": true
-	}
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["ESNext"],
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "isolatedModules": false,
+    "outFile": "./dist/index.d.ts"
+  },
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
**Client library**
SWC doesn't emit types. This PR makes use of `tsc` to generate the types when building the lib.